### PR TITLE
Add release workflow for tag-based GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that triggers on `v*` tag pushes
- Automatically creates GitHub Releases using `gh release create --generate-notes`
- Uses pinned `actions/checkout` digest consistent with existing CI

## Test plan
- [ ] Push a test tag (e.g. `v0.0.2`) and verify a GitHub Release is created with auto-generated notes